### PR TITLE
chore(ci): add GitHub actions deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+# If this workflow is triggered by a push to $default_branch, it
+#        deploys a SNAPSHOT
+# If this workflow is triggered by publishing a Release, it
+#        deploys a RELEASE with the selected version
+#        updates the project version by incrementing the patch version
+#        commits the version update change to the repository's default branch ($default_branch).
+name: Deploy artifacts with Maven
+on:
+  push:
+    branches: [$default_branch]
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Set up Java environment
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
+        gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
+    - name: Deploy SNAPSHOT / Release
+      uses: camunda-community-hub/community-action-maven-release@v1
+      with:
+        release-version: ${{ github.event.release.tag_name }}
+        release-profile: community-action-maven-release
+        nexus-usr: ${{ secrets.NEXUS_USR }}
+        nexus-psw: ${{ secrets.NEXUS_PSW }}
+        maven-usr: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_USR }}
+        maven-psw: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
+        maven-gpg-passphrase: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+      id: release
+    - if: github.event.release
+      name: Attach artifacts to GitHub Release (Release only)
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ${{ steps.release.outputs.artifacts_archive_path }}
+        asset_name: ${{ steps.release.outputs.artifacts_archive_path }}
+        asset_content_type: application/zip


### PR DESCRIPTION
This PR adds the deployment workflow as of [INFRA-1803](https://jira.camunda.com/browse/INFRA-1803).

In order to use this flow, repostories must be onboarded to [camunda-community-hub/infrastructure](https://github.com/camunda-community-hub/infrastructure/blob/master/terraform/github/repositories.tf)